### PR TITLE
Fix heap-buffer overwrite

### DIFF
--- a/Prog5.c
+++ b/Prog5.c
@@ -10,7 +10,7 @@ char * compress(char *str)
     length = strlen(str);
     if(length == 0 || length == 1) return str;
 
-    char *newStr = (char *)malloc(length * 2);
+    char *newStr = (char *)malloc(length * 2 + 1);
 
     for (i = 0, j = 0; i < length; i++)
     {


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).

You can trigger the out-of-bounds write with a string of `aba` that would result in the compressed string `a1b1a1` which needs `length * 2 + 1` bytes including the `NULL` terminator. 